### PR TITLE
Document coreos/first_boot for migrated machines

### DIFF
--- a/ignition/boot-process.md
+++ b/ignition/boot-process.md
@@ -8,7 +8,7 @@ The Flatcar Container Linux startup process is built on the standard [Linux star
 
 First, the GRUB config [specifies which `usr` partition to use][gptprio.next] from the two `usr` partitions Flatcar Container Linux uses to provide atomic upgrades and rollbacks.
 
-Second, GRUB [checks for a file called `flatcar/first_boot` in the EFI System Partition][check-file] to determine if this is the first time a machine has booted. If that file is found, GRUB sets the `flatcar.first_boot=detected` Linux kernel command line parameter. This parameter is used in later stages of the boot process.
+Second, GRUB [checks for a file called `flatcar/first_boot` in the EFI System Partition][check-file] to determine if this is the first time a machine has booted (or it checks for `coreos/first_boot` if the machine was updated from CoreOS CL). If that file is found, GRUB sets the `flatcar.first_boot=detected` Linux kernel command line parameter. This parameter is used in later stages of the boot process.
 
 Finally, GRUB [searches for the initial disk GUID][search-guid] (00000000-0000-0000-0000-000000000001) built into Flatcar Container Linux images. This GUID is randomized later in the boot process so that individual disks may be uniquely identified. If GRUB finds this GUID it sets another Linux kernel command line parameter, `flatcar.randomize_guid=00000000-0000-0000-0000-000000000001`.
 
@@ -24,7 +24,7 @@ If the `flatcar.first_boot` kernel parameter is provided and non-zero, Ignition 
 
 When Ignition runs on Flatcar Container Linux, it reads the Linux command line, looking for `flatcar.oem.id`. Ignition uses this identifier to determine where to read the user-provided configuration and which provider-specific configuration to combine with the user's. This provider-specific configuration performs basic machine setup, and may include enabling `coreos-metadata-sshkeys@.service` (covered in more detail below).
 
-After Ignition runs successfully, if `flatcar.first_boot` was set to the special value `detected`, Ignition mounts the EFI System Partition and deletes the `flatcar/first_boot` file.
+After Ignition runs successfully, if `flatcar.first_boot` was set to the special value `detected`, Ignition mounts the EFI System Partition and deletes the `flatcar/first_boot` file (or `coreos/first_boot` if the machine was updated from CoreOS CL).
 
 ## User space
 

--- a/ignition/what-is-ignition.md
+++ b/ignition/what-is-ignition.md
@@ -26,9 +26,9 @@ The lack of variable substitution in Ignition has an added benefit of leveling t
 
 ### When is Ignition executed
 
-On boot, GRUB checks the EFI System Partition for a file at `flatcar/first_boot` and sets `flatcar.first_boot=detected` if found. The `flatcar.first_boot` parameter is processed by a [systemd-generator] in the [initramfs] and if the parameter value is non-zero, the Ignition units are set as dependencies of `initrd.target`, causing Ignition to run. If the parameter is set to the special value `detected`, the `flatcar/first_boot` file is deleted after Ignition runs successfully.
+On boot, GRUB checks the EFI System Partition for a file at `flatcar/first_boot` (or `coreos/first_boot` if the machine was updated from CoreOS CL) and sets `flatcar.first_boot=detected` if found. The `flatcar.first_boot` parameter is processed by a [systemd-generator] in the [initramfs] and if the parameter value is non-zero, the Ignition units are set as dependencies of `initrd.target`, causing Ignition to run. If the parameter is set to the special value `detected`, the `flatcar/first_boot` (or `coreos/first_boot`) file is deleted after Ignition runs successfully.
 
-Note that [PXE][supported-platforms] deployments don't use GRUB to boot, so `flatcar.first_boot=1` must be added to the boot arguments in order for Ignition to run. `detected` should not be specified so Ignition will not attempt to delete `flatcar/first_boot`.
+Note that [PXE][supported-platforms] deployments don't use GRUB to boot, so `flatcar.first_boot=1` must be added to the boot arguments in order for Ignition to run. `detected` should not be specified so Ignition will not attempt to delete `flatcar/first_boot` (or `coreos/first_boot`).
 
 ## Providing Ignition a config
 

--- a/os/sdk-disk-partitions.md
+++ b/os/sdk-disk-partitions.md
@@ -50,7 +50,7 @@ The data stored on the root partition isn't manipulated by the update process. I
 
 Due to the unique disk layout of Flatcar Container Linux, an `rm -rf --one-file-system --no-preserve-root /` is an unsupported but valid operation to purge any OS data. On the next boot, the machine should just start from a clean state.
 
-To [re-provision][provisioning] the node after such cleanup, use `touch /boot/flatcar/first_boot` to trigger Ignition [to run once][boot process] again on the next boot.
+To [re-provision][provisioning] the node after such cleanup, use `touch /boot/flatcar/first_boot` to trigger Ignition [to run once][boot process] again on the next boot (if the machine was updated from CoreOS Container Linux, you need to use `/boot/coreos/first_boot`).
 
 [provisioning]: ../os/provisioning.md
 [boot process]: ../ignition/boot-process.md


### PR DESCRIPTION
If a machine was updated to Flatcar CL from CoreOS CL
it still has the old GRUB code which checks for
/boot/coreos/first_boot.
Document that this path is used for machines that
are migrated from CoreOS CL.