### PR TITLE
Document release dates in migration notes

### DIFF
--- a/os/migrate-from-container-linux.md
+++ b/os/migrate-from-container-linux.md
@@ -15,7 +15,7 @@ _Optional:_ Instead of providing the `coreos.first_boot=1` argument via the boot
 This forces provisioning via Ignition even if the machine (image) was booted already before.
 
 Instead of providing the `coreos.config.url=SOMEURL` argument via the boot loader you need to provide `ignition.config.url=SOMEURL`
-to tell Ignition to download the configuration.
+to tell Ignition to download the configuration (compatibility for `coreos.config.url` is planned for releases after 2020/03/16).
 The change to a more generic name was done upstream by the Ignition project. Version 0.33 still supports both names and we
 also do this via the analogous `flatcar.config.url` option but we encourage the generic name because future versions of Ignition
 will only support `ignition.config.url`.
@@ -39,6 +39,5 @@ The value in the argument pair specifies the Ignition file to use.
 
 ## Ignition configuration with VMware
 
-_Optional:_ Instead of `coreos.config.data` and `coreos.config.data.encoding` for the VMware `guestinfo.VARIABLE` command line options you need
-to use `ignition.config.data` and `ignition.config.data.encoding`.
-As for the kernel parameter this change was done upstream by the Ignition project.
+_Optional (planned for releases after 2020/03/16):_ Instead of `coreos.config.data` and `coreos.config.data.encoding` for the VMware `guestinfo.VARIABLE` command line options you should use `ignition.config.data` and `ignition.config.data.encoding`.
+Same as for the `ignition.config.url` kernel parameter this change was done upstream by the Ignition project.


### PR DESCRIPTION
The ignition.config.url migration is currently
needed but not in the next release.
The ignition.config.data migration is currently
not possible but can be done from the next
release on.

Fixes https://github.com/flatcar-linux/Flatcar/issues/45