### PR TITLE
Fix broken link to Provisioning site

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -459,7 +459,7 @@ First we need to create a security group to allow Flatcar Container Linux instan
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
+          Use <a href="https://docs.flatcar-linux.org/os/provisioning/#config-transpiler">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
           ```yaml
           etcd:
             # All options get passed as command line flags to etcd.


### PR DESCRIPTION
Also, instead of pointing to the site,
directly jump to the relevant section.