### PR TITLE
Update URL to sdk-modifying-flatcar

### DIFF
--- a/os/developer-guides.md
+++ b/os/developer-guides.md
@@ -13,6 +13,6 @@ Most users will never have to build Flatcar Container Linux from source or modif
 [sdk-tips]: sdk-tips-and-tricks.md
 [disk-layout]: sdk-disk-partitions.md
 [production-images]: sdk-building-production-images.md
-[mod-cl]: sdk-modifying-coreos.md
+[mod-cl]: sdk-modifying-flatcar.md
 [kernel-modules]: kernel-modules.md
 [mantle-utils]: https://github.com/flatcar-linux/mantle/blob/master/README.md#kola

--- a/os/sdk-modifying-flatcar.md
+++ b/os/sdk-modifying-flatcar.md
@@ -143,7 +143,7 @@ You could instead use the `-nographic` option, `./flatcar_production_qemu.sh -no
 
 You could also log in via SSH by running `./flatcar_production_qemu.sh` and then running `ssh core@127.0.0.1 -p 2222` to enter the guest OS. Running without the `-p 2222` option will arise a *ssh: connect to host 127.0.0.1 port 22: Connection refused* or *Permission denied (publickey,gssapi-keyex,gssapi-with-mic)* warning. Additionally, you can log in via SSH keys or with a different ssh port by running this example `./flatcar_production_qemu.sh -a ~/.ssh/authorized_keys -p 2223 -- -curses`. Refer to the [Booting with QEMU](booting-with-qemu.md#SSH-keys) guide for more information on this usage.
 
-The default login username is `core` and the [password is the one set in the `./set_shared_user_password`](sdk-modifying-coreos.md#Building-an-image) step of this guide. If you forget your password, you will need to rerun `./set_shared_user_password` and then `./build_image` again.
+The default login username is `core` and the [password is the one set in the `./set_shared_user_password`](sdk-modifying-flatcar.md#Building-an-image) step of this guide. If you forget your password, you will need to rerun `./set_shared_user_password` and then `./build_image` again.
 
 ## Making changes
 


### PR DESCRIPTION
Before this patch, the URL was
https://docs.flatcar-linux.org/os/sdk-modifying-coreos/

