### PR TITLE
vmware: Use guestinfo.coreos.config.* until fix is released

### DIFF
--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -124,9 +124,9 @@ Guestinfo configuration set via the VMware API or with `vmtoolsd` from within th
 
 ### Defining the Ignition config in Guestinfo
 
-If the `guestinfo.ignition.config.data` property is set, Ignition will apply the referenced config on first boot.
+If the `guestinfo.coreos.config.data` property is set, Ignition will apply the referenced config on first boot.
 
-The Ignition config is prepared for the guestinfo facility in one of two encoding types, specified in the `guestinfo.ignition.config.data.encoding` variable:
+The Ignition config is prepared for the guestinfo facility in one of two encoding types, specified in the `guestinfo.coreos.config.data.encoding` variable:
 
 |    Encoding    |                        Command                        |
 |:---------------|:------------------------------------------------------|
@@ -136,8 +136,8 @@ The Ignition config is prepared for the guestinfo facility in one of two encodin
 #### Example
 
 ```
-guestinfo.ignition.config.data = "ewogICJpZ25pdGlvbiI6IHsgInZlcnNpb24iOiAiMi4wLjAiIH0KfQo="
-guestinfo.ignition.config.data.encoding = "base64"
+guestinfo.coreos.config.data = "ewogICJpZ25pdGlvbiI6IHsgInZlcnNpb24iOiAiMi4wLjAiIH0KfQo="
+guestinfo.coreos.config.data.encoding = "base64"
 ```
 
 This example will be decoded into:

--- a/os/migrate-from-container-linux.md
+++ b/os/migrate-from-container-linux.md
@@ -39,5 +39,5 @@ The value in the argument pair specifies the Ignition file to use.
 
 ## Ignition configuration with VMware
 
-_Optional (planned for releases after 2020/03/16):_ Instead of `coreos.config.data` and `coreos.config.data.encoding` for the VMware `guestinfo.VARIABLE` command line options you should use `ignition.config.data` and `ignition.config.data.encoding`.
+_Optional (planned for releases after 2020/04/21):_ Instead of `coreos.config.data` and `coreos.config.data.encoding` for the VMware `guestinfo.VARIABLE` command line options you should use `ignition.config.data` and `ignition.config.data.encoding`.
 Same as for the `ignition.config.url` kernel parameter this change was done upstream by the Ignition project.


### PR DESCRIPTION
The guestinfo.ignition.config.* variables did not work when used
as direct guestinfo variables but only via the ovfenv.
Document to use the old variables in the mean time and update the
date after which releases will be able to use the new generic variables.
