### PR TITLE
booting-on-ec2: added paragraph on release retention

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -2,6 +2,10 @@
 
 The current AMIs for all Flatcar Container Linux channels and EC2 regions are listed below and updated frequently. Using CloudFormation is the easiest way to launch a cluster, but it is also possible to follow the manual steps at the end of the article. Questions can be directed to the Flatcar Container Linux [IRC channel][irc] or [user mailing list][flatcar-user].
 
+## Release retention time
+
+After publishing, releases will remain available as public AMIs on AWS for 9 months. AMIs older than 9 months will be un-published in regular garbage collection sweeps. Please note that this will not impact existing AWS instances that use those releases. However, deploying new instances (e.g. in autoscaling groups pinned to a specific AMI) will not be possible after the AMI was un-published.
+
 ## Choosing a channel
 
 Flatcar Container Linux is designed to be updated automatically with different schedules per channel. You can [disable this feature](update-strategies.md), although we don't recommend it. Read the [release notes](https://flatcar-linux.org/releases) for specific features and bug fixes.


### PR DESCRIPTION
# Add paragraph on AWS release retention

This PR adds a paragraph on release retention for AWS AMIs to the AWS section of the Flatcar Container Linux documentation (inspired by our latest AMI garbage collection issue, https://github.com/flatcar-linux/Flatcar/issues/85).

# How to use

Go to https://github.com/flatcar-linux/docs/blob/t-lo/ami-release-retention/os/booting-on-ec2.md, see 2nd paragraph.

# Testing done

Reviewed github's markdown rendering of the abovementioned document, second paragraph.