### PR TITLE
os: fix example of checking for SDK dependencies

### DIFF
--- a/os/sdk-tips-and-tricks.md
+++ b/os/sdk-tips-and-tricks.md
@@ -29,7 +29,7 @@ emerge-amd64-usr --emptytree -p -v --tree coreos-base/coreos-dev
 Get a tree view of the SDK dependencies:
 
 ```sh
-emerge-amd64-usr --emptytree -p -v --tree coreos-base/hard-host-depends
+emerge --emptytree -p -v --tree coreos-base/hard-host-depends coreos-devel/sdk-depends
 ```
 
 ## Add new upstream package


### PR DESCRIPTION
Unfortunately it is not enough to check for `coreos-base/hard-host-depends`.
We should also check for dependencies of `coreos-devel/sdk-depends`.

When checking for SDK dependencies, we should call `emerge` instead of `emerge-amd64-usr`. It is to be installed under the SDK environment, instead of in images.
