### PR TITLE
update-from-container-linux: Create symlink for cloud-config user_data

### DIFF
--- a/os/update-from-container-linux.md
+++ b/os/update-from-container-linux.md
@@ -42,7 +42,11 @@ Then, you need to edit `/usr/share/coreos/release` and replace the value of `COR
 COREOS_RELEASE_VERSION=0.0.0
 ```
 
-**NOTE:** In bare metal installations, the path where `user_data` is expected changes from `/var/lib/coreos-install/user_data` to `/var/lib/flatcar-install/user_data`. Make sure you place your `user_data` in the new path.
+Migrate any cloud-config `user_data` if it exists in `/var/lib/coreos-install/user_data` (e.g., in bare metal installations):
+
+```
+$ [ -d /var/lib/coreos-install ] && sudo ln -sn /var/lib/coreos-install /var/lib/flatcar-install
+```
 
 ## Restart service and reboot
 

--- a/update-to-flatcar.sh
+++ b/update-to-flatcar.sh
@@ -12,6 +12,7 @@ sudo umount /usr/share/coreos/release || true
 cp /usr/share/coreos/release /tmp/release
 sed -E -i "s/(COREOS_RELEASE_VERSION=)(.*)/\10.0.0/" /tmp/release
 sudo mount --bind /tmp/release /usr/share/coreos/release
+[ -d /var/lib/coreos-install ] && [ ! -e /var/lib/flatcar-install ] && sudo ln -sn /var/lib/coreos-install /var/lib/flatcar-install
 sudo systemctl restart update-engine
 update_engine_client -update
 echo "Done, please reboot now"


### PR DESCRIPTION
The note to migrate was not having instructions how to do it and migration
was not part of the automatic script.
Add it in a way that it only runs if necessary and only uses a symlink so
that rolling back to the CoreOS partition will work.

# How to use

Update a CoreOS CL VM to Flatcar CL with the script. If the `/var/lib/coreos-install` folder exists, a symlink should be created.


# Testing done

Tested that running the script multiple times works.