### PR TITLE
os/manual-rollback: Set tries to 1 for an unsuccessful partition

### DIFF
--- a/os/manual-rollbacks.md
+++ b/os/manual-rollbacks.md
@@ -44,7 +44,7 @@ $ cgpt show /dev/sda
     41943039           1          Sec GPT header
 ```
 
-Looking specifically at "USR-A" and "USR-B", we see that "USR-A" is the active USR partition (this is what's actually mounted at /usr). Its priority is higher than that of "USR-B". When the system boots, GRUB (the bootloader) looks at the priorities, tries, and successful flags to determine which partition to use.
+Looking specifically at "USR-A" and "USR-B", we see that "USR-A" is the active USR partition (this is what's actually mounted at /usr; you can verify this with `rootdev -s /usr`). Its priority is higher than that of "USR-B". When the system boots, GRUB (the bootloader) looks at the priorities, tries, and successful flags to determine which partition to use.
 
 ```
       270336     2097152       3  Label: "USR-A"
@@ -97,6 +97,7 @@ Now we see that the number of tries for "USR-B" has been decremented to zero. Th
                                   Attr: priority=2 tries=0 successful=1
 ```
 
+**Note:** You may also see `Alias for coreos-rootfs` shown for the `/usr` partition instead of the `flatcar-rootfs`. To refer to them you can use both names or the more appropriate `flatcar-usr` name which we will use from now on.
 
 ## Performing a manual rollback
 
@@ -148,6 +149,14 @@ Composing the previous two commands produces the following command to set the cu
 ```
 $ cgpt prioritize "$(cgpt find -t flatcar-usr | grep --invert-match "$(rootdev -s /usr)")"
 ```
+
+In the above scenario, _tries_ can stay 0 because the partition was marked as _successful_.
+If the partition was not successfully booted, we also need to set the available _tries_ to 1 again:
+
+```
+$ cgpt add -T 1 /dev/sda3
+```
+
 
 ## Forcing a Channel Downgrade
 

--- a/os/update-from-container-linux.md
+++ b/os/update-from-container-linux.md
@@ -93,7 +93,7 @@ $ sudo cgpt prioritize "$(sudo cgpt find -t flatcar-usr | grep --invert-match "$
 Now you can reboot and you'll be back to CoreOS Container Linux.
 Remember to undo your changes in your `/etc/coreos/update.conf` after rolling back if you want to keep getting CoreOS Container Linux updates.
 
-For more information about manual rollbacks, check [Performing a manual rollback](https://coreos.com/os/docs/latest/manual-rollbacks.html#performing-a-manual-rollback).
+For more information about manual rollbacks, check [Performing a manual rollback](/os/manual-rollbacks/#performing-a-manual-rollback).
 
 ### Force an update to CoreOS Container Linux
 


### PR DESCRIPTION
Mention that "tries" needs to be set to 1 if the partition was not
successfully booted before but should be prioritized now.
Also add a note on the partition aliases and fix a link.
