### PR TITLE
update-from-container-linux: Migrate /etc/coreos/update.conf

### DIFF
--- a/os/update-from-container-linux.md
+++ b/os/update-from-container-linux.md
@@ -22,7 +22,14 @@ $ sudo mount --bind /tmp/key /usr/share/update_engine/update-payload-key.pub.pem
 
 ## Modifying the configuration files
 
-Now, you need to point update_engine to Flatcar's update server by setting the `SERVER` configuration option in `/etc/coreos/update.conf`:
+Migrate your `/etc/coreos/update.conf` settings but keep a symlink:
+
+```
+sudo mv /etc/coreos /etc/flatcar
+sudo ln -s flatcar /etc/coreos
+```
+
+Now, you need to point update_engine to Flatcar's update server by setting the `SERVER` configuration option in `/etc/flatcar/update.conf`:
 
 ```
 SERVER=https://public.update.flatcar-linux.net/v1/update/
@@ -50,12 +57,16 @@ $ [ -d /var/lib/coreos-install ] && sudo ln -sn /var/lib/coreos-install /var/lib
 
 ## Restart service and reboot
 
-After that, restart the update service so it rescans the edited configuration and initiates an update.
-The system will reboot into Flatcar Container Linux:
+After that, restart the update service so it rescans the edited configuration. Initiate an immediate update.
+This takes some time. Afterwards remove the `SERVER` parameter from the `update.conf` file because it is already
+specified in the `/usr/share/flatcar/update.conf` file on the new partititon.
+Usually 5 minutes after the update finished, the system will reboot into Flatcar Container Linux, but you can also reboot manually:
 
 ```
 $ sudo systemctl restart update-engine
 $ update_engine_client -update
+$ sudo sed -i "/SERVER=.*/d" /etc/flatcar/update.conf
+$ sudo systemctl reboot
 ```
 
 ## All steps in one script

--- a/update-to-flatcar.sh
+++ b/update-to-flatcar.sh
@@ -5,8 +5,10 @@ sudo rm -f /tmp/key
 curl -L -o /tmp/key https://raw.githubusercontent.com/flatcar-linux/coreos-overlay/flatcar-master/coreos-base/coreos-au-key/files/official-v2.pub.pem
 sudo umount /usr/share/update_engine/update-payload-key.pub.pem || true
 sudo mount --bind /tmp/key /usr/share/update_engine/update-payload-key.pub.pem
-sudo sed -i "/SERVER=.*/d" /etc/coreos/update.conf
-echo "SERVER=https://public.update.flatcar-linux.net/v1/update/" | sudo tee -a /etc/coreos/update.conf
+sudo mv /etc/coreos /etc/flatcar
+sudo ln -s flatcar /etc/coreos
+sudo sed -i "/SERVER=.*/d" /etc/flatcar/update.conf
+echo "SERVER=https://public.update.flatcar-linux.net/v1/update/" | sudo tee -a /etc/flatcar/update.conf
 sudo rm -f /tmp/release
 sudo umount /usr/share/coreos/release || true
 cp /usr/share/coreos/release /tmp/release
@@ -15,4 +17,5 @@ sudo mount --bind /tmp/release /usr/share/coreos/release
 [ -d /var/lib/coreos-install ] && [ ! -e /var/lib/flatcar-install ] && sudo ln -sn /var/lib/coreos-install /var/lib/flatcar-install
 sudo systemctl restart update-engine
 update_engine_client -update
+sudo sed -i "/SERVER=.*/d" /etc/flatcar/update.conf
 echo "Done, please reboot now"


### PR DESCRIPTION
Any setting in /etc/coreos/update.conf was lost because the file
wasn't migrated to the new location.
Move it to the new location but keep a symlink. The SERVER parameter
won't be for Flatcar and was overwritten anyway and would be a duplicate
from the SERVER parameter in /usr/share/flatcar/update.conf.

# How to use/testing done

Download a QEMU CoreOS CL image and the script to run it.
Copy the migration script to the VM and run it.
Check that the `/etc/flatcar/update.conf` file after rebooting contains `GROUP=stable`.