### PR TITLE
update_engine_client requires sudo access

### DIFF
--- a/os/update-from-container-linux.md
+++ b/os/update-from-container-linux.md
@@ -64,7 +64,7 @@ Usually 5 minutes after the update finished, the system will reboot into Flatcar
 
 ```
 $ sudo systemctl restart update-engine
-$ update_engine_client -update
+$ sudo update_engine_client -update
 $ sudo sed -i "/SERVER=.*/d" /etc/flatcar/update.conf
 $ sudo systemctl reboot
 ```
@@ -154,5 +154,5 @@ The system will reboot into CoreOS Container Linux:
 
 ```
 $ sudo systemctl restart update-engine
-$ update_engine_client -update
+$ sudo update_engine_client -update
 ```

--- a/update-to-flatcar.sh
+++ b/update-to-flatcar.sh
@@ -16,6 +16,6 @@ sed -E -i "s/(COREOS_RELEASE_VERSION=)(.*)/\10.0.0/" /tmp/release
 sudo mount --bind /tmp/release /usr/share/coreos/release
 [ -d /var/lib/coreos-install ] && [ ! -e /var/lib/flatcar-install ] && sudo ln -sn /var/lib/coreos-install /var/lib/flatcar-install
 sudo systemctl restart update-engine
-update_engine_client -update
+sudo update_engine_client -update
 sudo sed -i "/SERVER=.*/d" /etc/flatcar/update.conf
 echo "Done, please reboot now"


### PR DESCRIPTION
after running the update from coreos to flatcar, it failed as `update_engine_client` was requiring root access