### PR TITLE
what-is-ignition.md: link to v2.x spec examples instead of v3.x

### DIFF
--- a/ignition/what-is-ignition.md
+++ b/ignition/what-is-ignition.md
@@ -40,10 +40,10 @@ The [full list of supported platforms][supported-platforms] is provided and will
 
 Ignition is under active development. Expect to see support for more images in the coming months.
 
-[examples]: https://github.com/flatcar-linux/ignition/blob/master/doc/examples.md
+[examples]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.md
 [cloudinit]: https://github.com/flatcar-linux/coreos-cloudinit
 [network-config]: network-configuration.md
-[custom-agent]: https://github.com/flatcar-linux/ignition/blob/master/doc/examples.md#custom-metadata-agent
-[supported-platforms]: https://github.com/flatcar-linux/ignition/blob/master/doc/supported-platforms.md
+[custom-agent]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/examples.md#custom-metadata-agent
+[supported-platforms]: https://github.com/flatcar-linux/ignition/blob/flatcar-master/doc/supported-platforms.md
 [systemd-generator]: http://www.freedesktop.org/software/systemd/man/systemd.generator.html
 [initramfs]: https://www.kernel.org/doc/Documentation/filesystems/ramfs-rootfs-initramfs.txt


### PR DESCRIPTION
# Reference correct ignition spec version (v2.x instead of v3.x)

The `ignition` section of the Flatcar Container Linux documents currently references the incorrect version of the ignition specification - v3.x. v3.x is not supported at this time as Flatcar Container Linux ships `ignition` binary v0.3x, which supports v2.x of the spec.
