### PR TITLE
*: point docs to the Flatcar or current links

### DIFF
--- a/index.md
+++ b/index.md
@@ -97,7 +97,7 @@ APIs and troubleshooting guides for working with Flatcar Container Linux.
 [config-examples]: container-linux-config-transpiler/doc/examples.md
 [config-spec]: container-linux-config-transpiler/doc/configuration.md
 [config-notes]: container-linux-config-transpiler/doc/operators-notes.md
-[matchbox]: https://github.com/coreos/matchbox/blob/master/README.md
+[matchbox]: https://matchbox.psdn.io/
 [ipxe]: os/booting-with-ipxe.md
 [pxe]: os/booting-with-pxe.md
 [install-to-disk]: os/installing-to-disk.md

--- a/os/cluster-architectures.md
+++ b/os/cluster-architectures.md
@@ -86,7 +86,7 @@ Once you have a small cluster up and running, you can install a Kubernetes on th
 
 ### Configuring the machines
 
-For more information on getting started with this architecture, see the Flatcar Container Linux documentation on [supported platforms][flatcar-supported]. These include [Amazon EC2][flatcar-ec2], [Openstack][flatcar-openstack], [Azure][flatcar-azure], [Google Compute Platform][flatcar-gce], [bare metal iPXE][flatcar-bm], [Digital Ocean][flatcar-do], and many more community supported platforms.
+For more information on getting started with this architecture, see the Flatcar Container Linux documentation on [supported platforms][flatcar-supported]. These include [Amazon EC2][flatcar-ec2], [Packet][flatcar-packet], [Azure][flatcar-azure], [Google Compute Platform][flatcar-gce], [bare metal iPXE][flatcar-bm], [Digital Ocean][flatcar-do], and many more community supported platforms.
 
 Boot the desired number of machines with the same CL Config and discovery token. The CL Config specifies which services will be started on each machine.
 
@@ -165,7 +165,7 @@ For large clusters, it's recommended to set aside 3-5 machines to run central se
 
 Our central services machines will run services like etcd and Kubernetes controllers that support the rest of the cluster. etcd is configured with static networking and a peers list.
 
-[Flatcar Container Linux Support][flatcar-managed] customers can also specify a [CoreUpdate][core-update] group ID which allows you to subscribe these machines to a different update channel, controlling updates separately from the worker machines.
+[Flatcar Container Linux Support][flatcar-managed] customers can also specify a [Update Service][nebraska-update] group ID which allows you to subscribe these machines to a different [update channel][flatcar-channels], controlling updates separately from the worker machines.
 
 Here's an example CL Config for one of the central service machines. Be sure to generate a new discovery token with the initial size of your cluster:
 
@@ -197,19 +197,19 @@ networkd:
         Gateway=10.0.0.1
 ```
 
-[ct-download]: https://github.com/coreos/container-linux-config-transpiler/releases
+[ct-download]: https://github.com/flatcar-linux/container-linux-config-transpiler
 [ignition-getting-started]: https://coreos.com/ignition/docs/latest/getting-started.html
 [ignition-supported]: https://coreos.com/ignition/docs/latest/supported-platforms.html
-[flatcar-qemu]: https://coreos.com/os/docs/latest/booting-with-qemu.html
+[flatcar-qemu]: https://docs.flatcar-linux.org/os/booting-with-qemu/
 [minikube]: https://github.com/kubernetes/minikube
-[managed-linux]: https://coreos.com/products/managed-linux
-[core-update]: https://coreos.com/products/coreupdate
-[flatcar-supported]: https://coreos.com/os/docs/latest#running-coreos
-[flatcar-managed]: https://coreos.com/products/managed-linux
-[flatcar-ec2]: https://coreos.com/os/docs/latest/booting-on-ec2.html
-[flatcar-openstack]: https://coreos.com/os/docs/latest/booting-on-openstack.html
-[flatcar-azure]: https://coreos.com/os/docs/latest/booting-on-azure.html
-[flatcar-gce]: https://coreos.com/os/docs/latest/booting-on-google-compute-engine.html
-[flatcar-bm]: https://coreos.com/matchbox/
-[flatcar-do]: https://coreos.com/os/docs/latest/booting-on-digitalocean.html
+[nebraska-update]: https://github.com/kinvolk/nebraska
+[flatcar-channels]: https://www.flatcar-linux.org/releases/
+[flatcar-supported]: https://docs.flatcar-linux.org/
+[flatcar-managed]: https://kinvolk.io/flatcar-container-linux/#kinvolk-update-service
+[flatcar-ec2]: https://docs.flatcar-linux.org/os/booting-on-ec2/
+[flatcar-packet]: https://docs.flatcar-linux.org/os/booting-on-packet/
+[flatcar-azure]: https://docs.flatcar-linux.org/os/booting-on-azure/
+[flatcar-gce]: https://docs.flatcar-linux.org/os/booting-on-google-compute-engine/
+[flatcar-do]: https://docs.flatcar-linux.org/os/booting-on-digitalocean/
+[flatcar-bm]: https://docs.flatcar-linux.org/os/booting-with-ipxe/
 [typhoon]: https://github.com/poseidon/typhoon

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -198,7 +198,7 @@ storage:
 ```
 
 [timedatectl]: http://www.freedesktop.org/software/systemd/man/timedatectl.html
-[681.0.0]: https://coreos.com/releases/#681.0.0
+[681.0.0]: https://github.com/flatcar-linux/manifest/tree/build-681
 [ntp.org]: http://ntp.org/
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 [systemd.network]: http://www.freedesktop.org/software/systemd/man/systemd.network.html

--- a/os/customizing-docker.md
+++ b/os/customizing-docker.md
@@ -72,8 +72,8 @@ Docker TLS configuration consists of three parts: keys creation, configuring new
 Please follow the [instruction][self-signed-certs] to know how to create self-signed certificates and private keys. Then copy the following files into `/etc/docker` Flatcar Container Linux's directory and fix their permissions:
 
 ```sh
-scp ~/cfssl/{server.pem,server-key.pem,ca.pem} coreos.example.com:
-ssh core@coreos.example.com
+scp ~/cfssl/{server.pem,server-key.pem,ca.pem} flatcar.example.com:
+ssh core@flatcar.example.com
 sudo mv {server.pem,server-key.pem,ca.pem} /etc/docker/
 sudo chown root:root /etc/docker/{server-key.pem,server.pem,ca.pem}
 sudo chmod 0600 /etc/docker/server-key.pem
@@ -343,5 +343,5 @@ A json file `.dockercfg` can be created in your home directory that holds authen
 [mounting-storage]: mounting-storage.md
 [self-signed-certs]: generate-self-signed-certificates.md
 [systemd-socket]: https://www.freedesktop.org/software/systemd/man/systemd.socket.html
-[systemd-env-vars]: https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#system-wide-environment-variables
+[systemd-env-vars]: https://docs.flatcar-linux.org/os/using-environment-variables-in-systemd-units/#system-wide-environment-variables
 [cl-configs]: provisioning.md

--- a/os/getting-started-with-docker.md
+++ b/os/getting-started-with-docker.md
@@ -30,14 +30,14 @@ After that completes, we need to `commit` these changes to our container with th
 
 To find the container ID, open another shell (so the container is still running) and read the ID using `docker ps`.
 
-The image name is in the format of `username/name`. We're going to use `coreos` as our username in this example but you should [sign up for a Docker.IO user account](https://hub.docker.com/account/signup/) and use that instead.
+The image name is in the format of `username/name`. We're going to use `flatcar` as our username in this example but you should [sign up for a Docker.IO user account](https://hub.docker.com/account/signup/) and use that instead.
 
 It's important to note that you can commit using any username and image name locally, but to push an image to the public registry, the username must be a valid [Docker.IO user account](https://hub.docker.com/account/signup/).
 
 Commit the container with the container ID, your username, and the name `apache`:
 
 ```sh
-docker commit 72d468f455ea coreos/apache
+docker commit 72d468f455ea flatcar/apache
 ```
 
 The overlay filesystem works similar to git: our image now builds off of the `ubuntu` base and adds another layer with Apache on top. These layers get cached separately so that you won't have to pull down the ubuntu base more than once.
@@ -50,10 +50,10 @@ Now we have our Ubuntu container with Apache running in one shell and an image o
 docker run [options] [image] [process]
 ```
 
-The first step is to tell Docker that we want to run our `coreos/apache` image:
+The first step is to tell Docker that we want to run our `flatcar/apache` image:
 
 ```sh
-docker run [options] coreos/apache [process]
+docker run [options] flatcar/apache [process]
 ```
 
 ### Run container detached
@@ -61,7 +61,7 @@ docker run [options] coreos/apache [process]
 When running Docker containers manually, the most important option is to run the container in detached mode with the `-d` flag. This will output the container ID to show that the command was successful, but nothing else. At any time you can run `docker ps` in the other shell to view a list of the running containers. Our command now looks like:
 
 ```sh
-docker run -d coreos/apache [process]
+docker run -d flatcar/apache [process]
 ```
 
 After you are comfortable with the mechanics of running containers by hand, it's recommended to use [systemd units](getting-started-with-systemd.md) to run your containers on a cluster of Flatcar Container Linux machines.
@@ -79,7 +79,7 @@ We need to run the apache process in the foreground, since our container will st
 Let's add that to our command:
 
 ```sh
-docker run -d coreos/apache /usr/sbin/apache2ctl -D FOREGROUND
+docker run -d flatcar/apache /usr/sbin/apache2ctl -D FOREGROUND
 ```
 
 ### Permanently running a container
@@ -93,7 +93,7 @@ Instead, create a systemd unit file to make systemd keep that container running.
 The default apache install will be running on port 80. To give our container access to traffic over port 80, we use the `-p` flag and specify the port on the host that maps to the port inside the container. In our case we want 80 for each, so we include `-p 80:80` in our command:
 
 ```sh
-docker run -d -p 80:80 coreos/apache /usr/sbin/apache2ctl -D FOREGROUND
+docker run -d -p 80:80 flatcar/apache /usr/sbin/apache2ctl -D FOREGROUND
 ```
 
 You can now run this command on your Flatcar Container Linux host to create the container. You should see the default apache webpage when you load either `localhost:80` or the IP of your remote server. Be sure that any firewall or EC2 Security Group allows traffic to port 80.
@@ -103,7 +103,7 @@ You can now run this command on your Flatcar Container Linux host to create the 
 Earlier we downloaded the ubuntu image remotely from the Docker public registry because it didn't exist on our local machine. We can also push local images to the public registry (or a private registry) very easily with the `push` command:
 
 ```sh
-docker push coreos/apache
+docker push flatcar/apache
 ```
 
 To push to a private repository the syntax is very similar. First, we must prefix our image with the host running our private registry instead of our username. List images by running `docker images` and insert the correct ID into the `tag` command:
@@ -126,6 +126,5 @@ docker run -d -p 80:80 registry.example.com:5000/apache /usr/sbin/apache2ctl -D 
 
 ## More information
 
-<a class="btn btn-default" href="https://coreos.com/why/#containers">Docker Overview</a>
 <a class="btn btn-default" href="http://www.docker.com/">Docker Website</a>
 <a class="btn btn-default" href="https://docs.docker.com/mac/started/">docker's Getting Started Guide</a>

--- a/os/installing-to-disk.md
+++ b/os/installing-to-disk.md
@@ -4,7 +4,7 @@
 
 There is a simple installer that will destroy everything on the given target disk and install Flatcar Container Linux. Essentially it downloads an image, verifies it with gpg, and then copies it bit for bit to disk. An installation requires at least 8 GB of usable space on the device.
 
-The script is self-contained and located [on GitHub here][flatcar-install] and can be run from any Linux distribution. You cannot normally install Flatcar Container Linux to the same device that is currently booted. However, the [Flatcar Container Linux ISO][coreos-iso] or any Linux liveCD will allow Flatcar Container Linux to install to a non-active device.
+The script is self-contained and located [on GitHub here][flatcar-install] and can be run from any Linux distribution. You cannot normally install Flatcar Container Linux to the same device that is currently booted. However, the [Flatcar Container Linux ISO][flatcar-iso] or any Linux liveCD will allow Flatcar Container Linux to install to a non-active device.
 
 If you boot Flatcar Container Linux via PXE, the install script is already installed. By default the install script will attempt to install the same version and channel that was PXE-booted:
 
@@ -22,7 +22,7 @@ flatcar-install -d /dev/sda -i ignition.json -o vmware_raw
 
 ## Choose a channel
 
-Flatcar Container Linux is designed to be [updated automatically](https://coreos.com/why/#updates) with different schedules per channel. You can [disable this feature](update-strategies.md), although we don't recommend it. Read the [release notes](https://flatcar-linux.org/releases) for specific features and bug fixes.
+Flatcar Container Linux is designed to be [updated automatically][update-strategies] with different schedules per channel. You can [disable this feature](update-strategies.md), although we don't recommend it. Read the [release notes](https://flatcar-linux.org/releases) for specific features and bug fixes.
 
 <div id="install">
   <ul class="nav nav-tabs">
@@ -132,7 +132,7 @@ systemd:
       - name: 50-network-config.conf
         contents: |
           [Service]
-          ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.1.0.0/16", "Backend": {"Type": "vxlan"}}'
+          ExecStartPre=/usr/bin/etcdctl set /kinvolk.io/network/config '{"Network":"10.1.0.0/16", "Backend": {"Type": "vxlan"}}'
 ```
 
 ## Using Flatcar Container Linux
@@ -141,7 +141,8 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 
 [quickstart]: quickstart.md
 [docs-root]: https://docs.flatcar-linux.org
-[coreos-iso]: booting-with-iso.md
+[update-strategies]: https://docs.flatcar-linux.org/os/update-strategies/
+[flatcar-iso]: booting-with-iso.md
 [clc-section]: #container-linux-configs
 [flatcar-install]: https://raw.githubusercontent.com/flatcar-linux/init/flatcar-master/bin/flatcar-install
 [cl-configs]: provisioning.md

--- a/os/notes-for-distributors.md
+++ b/os/notes-for-distributors.md
@@ -13,9 +13,9 @@ Each directory has a `version.txt` file containing version information for the f
 It is recommended that you also verify files using the [Flatcar Container Linux Image Signing Key][signing-key]. The GPG signature for each image is a detached `.sig` file that must be passed to `gpg --verify`. For example:
 
 ```sh
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
-wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2.sig
-gpg --verify flatcar_production_openstack_image.img.bz2.sig
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2
+wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2.sig
+gpg --verify flatcar_production_qemu_image.img.bz2.sig
 ```
 
 The signing key is rotated annually. We will announce upcoming rotations of the signing key on the [user mailing list][flatcar-user].
@@ -24,7 +24,7 @@ The signing key is rotated annually. We will announce upcoming rotations of the 
 [beta-bucket]: https://beta.release.flatcar-linux.net/amd64-usr/
 [edge-bucket]: https://edge.release.flatcar-linux.net/amd64-usr/
 [stable-bucket]: https://stable.release.flatcar-linux.net/amd64-usr/
-[signing-key]: https://coreos.com/security/image-signing-key
+[signing-key]: https://www.flatcar-linux.org/security/image-signing-key/
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user
 
 ## Image customization

--- a/os/quickstart.md
+++ b/os/quickstart.md
@@ -38,7 +38,7 @@ Flatcar Container Linux (beta)
 
 The first building block of Flatcar Container Linux is service discovery with **etcd** ([docs][etcd-docs]). Data stored in etcd is distributed across all of your machines running Flatcar Container Linux. For example, each of your app containers can announce itself to a proxy container, which would automatically know which machines should receive traffic. Building service discovery into your application allows you to add more machines and scale your services seamlessly.
 
-If you used an example [Container Linux Config][cl-configs] or [cloud-config](https://coreos.com/os/docs/latest/cloud-config.html) from a guide linked in the first paragraph, etcd is automatically started on boot.
+If you used an example [Container Linux Config][cl-configs] or [cloud-config](https://github.com/flatcar-linux/coreos-cloudinit/blob/master/Documentation/cloud-config.md) from a guide linked in the first paragraph, etcd is automatically started on boot.
 
 A good starting point for a Container Linux Config would be something like:
 
@@ -87,7 +87,7 @@ If you followed a guide to set up more than one Flatcar Container Linux machine,
 ### More detailed information
 
 <a class="btn btn-primary" href="https://coreos.com/etcd/docs/latest/getting-started-with-etcd.html" data-category="More Information" data-event="Docs: Getting Started etcd">View Complete Guide</a>
-<a class="btn btn-default" href="https://coreos.com/etcd/docs/latest/api.html">Read etcd API Docs</a>
+<a class="btn btn-default" href="https://etcd.io/docs/">Read etcd API Docs</a>
 
 ## Container management with Docker
 
@@ -107,11 +107,10 @@ docker run -i -t busybox /bin/sh
 
 ### More detailed information
 
-<a class="btn btn-primary" href="https://coreos.com/os/docs/latest/getting-started-with-docker.html" data-category="More Information" data-event="Docs: Getting Started docker">View Complete Guide</a>
 <a class="btn btn-default" href="http://docs.docker.io/">Read Docker Docs</a>
 
 [docker-docs]: https://docs.docker.com/
-[etcd-docs]: https://coreos.com/etcd/docs/latest/
+[etcd-docs]: https://etcd.io/
 [running-container-linux]: https://docs.flatcar-linux.org/#getting-started
 [ec2-docs]: booting-on-ec2.md
 [azure-docs]: booting-on-azure.md

--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -231,6 +231,6 @@ For details, check out the [Container Linux Config examples][ct-examples].
 [quay-robot]: https://docs.quay.io/glossary/robot-accounts.html
 [quay-site]: https://quay.io/
 [rfc-2397]: https://tools.ietf.org/html/rfc2397
-[rkt-config]: https://coreos.com/rkt/docs/latest/configuration.html#configuration-kinds
+[rkt-config]: https://docs.flatcar-linux.org/os/registry-authentication/#rkt
 [cl-configs]: provisioning.md
-[ct-examples]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/examples.md
+[ct-examples]: https://github.com/flatcar-linux/container-linux-config-transpiler/blob/flatcar-master/doc/examples.md

--- a/os/root-filesystem-placement.md
+++ b/os/root-filesystem-placement.md
@@ -2,7 +2,7 @@
 Flatcar Container Linux supports composite disk devices such as RAID arrays. If the root filesystem is placed on a composite device, special care must be taken to ensure Flatcar Container Linux can find and mount the filesystem early in the boot process. GPT partition entries have a [partition type GUID](https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs) that specifies what type of partition it is (e.g. Linux filesystem); Flatcar Container Linux uses special type GUIDs to indicate that a partition is a component of a composite device containing the root filesystem.
 
 ## Root on RAID
-RAID enables multiple disks to be combined into a single logical disk to increase reliability and performance. To create a software RAID array when provisioning a Flatcar Container Linux system, use the `storage.raid` section of a [Container Linux Config](https://coreos.com/os/docs/latest/provisioning.html). RAID components containing the root filesystem must have the type GUID `be9067b9-ea49-4f15-b4f6-f36f8c9e1818`. All other RAID arrays must not have that GUID; the Linux RAID partition GUID `a19d880f-05fc-4d3b-a006-743f0f84911e` is recommended instead. See the [Ignition documentation](https://coreos.com/ignition/docs/latest/examples.html#create-a-raid-enabled-data-volume) for more information on setting up RAID for data volumes.
+RAID enables multiple disks to be combined into a single logical disk to increase reliability and performance. To create a software RAID array when provisioning a Flatcar Container Linux system, use the `storage.raid` section of a [Container Linux Config](https://docs.flatcar-linux.org/os/root-filesystem-placement/). RAID components containing the root filesystem must have the type GUID `be9067b9-ea49-4f15-b4f6-f36f8c9e1818`. All other RAID arrays must not have that GUID; the Linux RAID partition GUID `a19d880f-05fc-4d3b-a006-743f0f84911e` is recommended instead. See the [Ignition documentation](https://coreos.com/ignition/docs/latest/examples.html#create-a-raid-enabled-data-volume) for more information on setting up RAID for data volumes.
 
 ### Overview
 To place the root filesystem on a RAID array:
@@ -13,7 +13,7 @@ To place the root filesystem on a RAID array:
  * Remove the `ROOT` label from the original root filesystem.
 
 ### Example Container Linux Config
-This Container Linux Config creates partitions on `/dev/vdb` and `/dev/vdc` that fill each disk, creates a RAID array named `root_array` from those partitions, and finally creates the root filesystem on the array. To prevent inadvertent booting from the [original root filesystem](https://coreos.com/os/docs/latest/sdk-disk-partitions.html#partition-table), `/dev/vda9` is reformatted with a blank ext4 filesystem labeled `unused`.
+This Container Linux Config creates partitions on `/dev/vdb` and `/dev/vdc` that fill each disk, creates a RAID array named `root_array` from those partitions, and finally creates the root filesystem on the array. To prevent inadvertent booting from the [original root filesystem](https://docs.flatcar-linux.org/os/sdk-disk-partitions/#partition-table), `/dev/vda9` is reformatted with a blank ext4 filesystem labeled `unused`.
 
 **Warning: This will erase both `/dev/vdb` and `/dev/vdc`.**
 ```yaml

--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -143,4 +143,4 @@ For more information about the supported syntax, refer to the [Locksmith documen
 
 [rollback]: manual-rollbacks.md
 [reboot-windows]: https://github.com/flatcar-linux/locksmith#reboot-windows
-[systemd-env-vars]: https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#system-wide-environment-variables
+[systemd-env-vars]: https://docs.flatcar-linux.org/os/using-environment-variables-in-systemd-units/#system-wide-environment-variables


### PR DESCRIPTION
Closes: #34

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# point docs to the Flatcar or current links

looks through for newer links or the current place the docs are hosted for Flatcar.


# How to use

View the docs.


# Testing done

Walked through the location of the link, and ensure the new location is up-to-date and relevant. 
