### PR TITLE
os/sdk-modifying-flatcar.md: Update cork version for new subkey

### DIFF
--- a/os/sdk-modifying-flatcar.md
+++ b/os/sdk-modifying-flatcar.md
@@ -36,8 +36,8 @@ The `cork` utility, included in the Flatcar Container Linux [mantle](https://git
 First, download the cork utility and verify it with the signature:
 
 ```sh
-curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v0.15.0/cork-0.15.0-amd64
-curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v0.15.0/cork-0.15.0-amd64.sig
+curl -L -o cork https://github.com/flatcar-linux/mantle/releases/download/v0.15.1/cork-0.15.1-amd64
+curl -L -o cork.sig https://github.com/flatcar-linux/mantle/releases/download/v0.15.1/cork-0.15.1-amd64.sig
 gpg --receive-keys 84C8E771C0DF83DFBFCAAAF03ADA89DEC2507883
 curl -LO https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc
 gpg --import Flatcar_Image_Signing_Key.asc


### PR DESCRIPTION
Tested that links work:
https://github.com/flatcar-linux/mantle/releases/download/v0.15.1/cork-0.15.1-amd64
https://github.com/flatcar-linux/mantle/releases/download/v0.15.1/cork-0.15.1-amd64.sig